### PR TITLE
add new line after the output

### DIFF
--- a/habash
+++ b/habash
@@ -76,3 +76,4 @@ function habash_createhabit {
 action=$1
 shift
 habash_${action} $@ 2>/dev/null ||echo "$action is not a valid action"
+printf "\n"


### PR DESCRIPTION
This is a tiny pull request to add the "\n" after the return.

Otherwise, sometimes it would make the terminal a little bit strange~~

We should work more on this project! The new web interface for Habitica is a little bit complicated to add the task (maybe intentional). A bash-style one attracts programmers and graduate students!